### PR TITLE
Fix: selection box in scrollable parent container

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "@air/react-drag-to-select",
-  "version": "5.0.5",
+  "name": "@deafnv/react-drag-to-select",
+  "version": "5.0.6",
   "description": "A performant React library which adds drag to select to your app",
   "type": "module",
   "author": "Air Labs, Inc.",
   "license": "MIT",
-  "repository": "AirLabsTeam/react-drag-to-select",
+  "repository": "deafnv/react-drag-to-select",
   "source": "src/index.ts",
   "exports": {
     "require": "./dist/index.cjs",

--- a/src/components/SelectionContainer.tsx
+++ b/src/components/SelectionContainer.tsx
@@ -19,6 +19,10 @@ export const SelectionContainer = forwardRef(({ style = {}, ...props }: Selectio
     (): SelectionContainerRef => ({
       getBoundingClientRect: () => containerRef.current?.getBoundingClientRect(),
       getParentBoundingClientRect: () => containerRef?.current?.parentElement?.getBoundingClientRect(),
+      getParentScroll: () => ({
+        scrollTop: containerRef.current?.parentElement?.scrollTop,
+        scrollLeft: containerRef.current?.parentElement?.scrollLeft
+      }),
       drawSelectionBox: (box: SelectionBox) => {
         requestAnimationFrame(() => {
           if (selectionBoxRef.current) {

--- a/src/hooks/useSelectionLogic.ts
+++ b/src/hooks/useSelectionLogic.ts
@@ -93,8 +93,8 @@ export function useSelectionLogic<T extends HTMLElement>({
       }
 
       return {
-        x: event.clientX - (rect?.left || 0),
-        y: event.clientY - (rect?.top || 0),
+        x: event.clientX - (rect?.left || 0) + (containerRef.current?.getParentScroll().scrollLeft || 0),
+        y: event.clientY - (rect?.top || 0) + (containerRef.current?.getParentScroll().scrollTop || 0),
       };
     },
     [containerRef],

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -19,4 +19,8 @@ export interface SelectionContainerRef {
   clearSelectionBox: () => void;
   getBoundingClientRect: () => DOMRect | undefined;
   getParentBoundingClientRect: () => DOMRect | undefined;
+  getParentScroll: () => {
+    scrollTop: number | undefined;
+    scrollLeft: number | undefined;
+  };
 }


### PR DESCRIPTION
Had an issue with selection in a scrollable parent container where the selection wouldn't select following the cursor if the container was being scrolled while selecting, see: https://codesandbox.io/s/staging-silence-q87qdx

Wasn't able to fix it without changing the package so I thought I'd submit a PR, not entirely sure if I'm missing anything here.

Fixed: https://codesandbox.io/s/red-wildflower-hvlwim