### PR TITLE
build: fix typings for TS 5+ moduleResolution: "bundler" option

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "source": "src/index.ts",
   "exports": {
     "require": "./dist/index.cjs",
+    "types": "./dist/index.d.ts",
     "default": "./dist/index.modern.js"
   },
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Since TypeScript 5+, there is now the option `"bundler"` for the tsconfig option `moduleResolution`. For such projects, the `typings` key of the `package.json` are not considered.

For this reason, the TypeScript compiler does not find the appropriate `index.d.ts` resulting in type errors.

Adding `types` to `exports["."]` in the `package.json` fixes this problem.

closes #41 