### PR TITLE
Adjust threshold logic to improve one-dimensional selections

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -28,7 +28,7 @@
     },
     "..": {
       "name": "@air/react-drag-to-select",
-      "version": "2.2.2",
+      "version": "5.0.8",
       "license": "MIT",
       "dependencies": {
         "react-style-object-to-css": "^1.1.2"

--- a/src/hooks/useSelectionContainer.tsx
+++ b/src/hooks/useSelectionContainer.tsx
@@ -17,7 +17,13 @@ export interface UseSelectionContainerResult {
 export interface UseSelectionContainerParams<T extends HTMLElement>
   extends Pick<
     UseSelectionLogicParams<T>,
-    'onSelectionChange' | 'onSelectionEnd' | 'onSelectionStart' | 'isEnabled' | 'eventsElement' | 'shouldStartSelecting'
+    | 'onSelectionChange'
+    | 'onSelectionEnd'
+    | 'onSelectionStart'
+    | 'isEnabled'
+    | 'eventsElement'
+    | 'shouldStartSelecting'
+    | 'isValidSelectionStart'
   > {
   /** These are props that get passed to the selection box component (where styling gets passed in) */
   selectionProps?: SelectionContainerProps;
@@ -38,6 +44,7 @@ export function useSelectionContainer<T extends HTMLElement>(
     selectionProps = {},
     eventsElement,
     shouldStartSelecting,
+    isValidSelectionStart,
   } = props || {};
 
   const containerRef = useRef<SelectionContainerRef>(null);
@@ -50,6 +57,7 @@ export function useSelectionContainer<T extends HTMLElement>(
     isEnabled,
     eventsElement,
     shouldStartSelecting,
+    isValidSelectionStart,
   });
 
   const DragSelection = useCallback(() => <SelectionContainer ref={containerRef} {...selectionProps} />, []);

--- a/src/hooks/useSelectionLogic.ts
+++ b/src/hooks/useSelectionLogic.ts
@@ -1,6 +1,6 @@
 import { RefObject, useCallback, useEffect, useRef } from 'react';
 import { SelectionContainerRef, OnSelectionChange, Point, SelectionBox, Box } from '../utils/types';
-import { calculateBoxArea, calculateSelectionBox } from '../utils/boxes';
+import { calculateSelectionBox } from '../utils/boxes';
 
 export interface UseSelectionLogicResult {
   cancelCurrentSelection: () => void;
@@ -120,7 +120,7 @@ export function useSelectionLogic<T extends HTMLElement>({
         };
 
         // we detect move only after some small movement
-        if (calculateBoxArea(newSelectionBox) > 10) {
+        if (newSelectionBox.height + newSelectionBox.width > 8) {
           if (!isSelecting.current) {
             if (currentSelectionStart?.current) {
               currentSelectionStart.current(event);

--- a/src/hooks/useSelectionLogic.ts
+++ b/src/hooks/useSelectionLogic.ts
@@ -30,7 +30,7 @@ export interface UseSelectionLogicParams<T extends HTMLElement> {
 
   /**
    * Determines whether a selection's dimensions meet the criteria for initiating a selection.
-   * The prupose is to distinguish between clicks and the start of a selection gesture.
+   * The purpose is to distinguish between clicks and the start of a selection gesture.
    *
    * The default implementation checks if the area of the box (width * height) is greater than 10.
    *
@@ -51,7 +51,7 @@ export function useSelectionLogic<T extends HTMLElement>({
   isEnabled = true,
   eventsElement,
   shouldStartSelecting,
-  isValidSelectionStart = isValidSelectionStartDefault,
+  isValidSelectionStart = isMinumumBoxArea,
 }: UseSelectionLogicParams<T>): UseSelectionLogicResult {
   const startPoint = useRef<null | Point>(null);
   const endPoint = useRef<null | Point>(null);
@@ -231,6 +231,6 @@ export function useSelectionLogic<T extends HTMLElement>({
   };
 }
 
-function isValidSelectionStartDefault(box: Box): boolean {
+function isMinumumBoxArea(box: Box): boolean {
   return calculateBoxArea(box) > 10;
 }


### PR DESCRIPTION
We've run into problems when trying to use this library for one-dimensional selections (rather than box selections). When selecting in a single direction, some trackpads will only move the cursor along a single axis, which meant that the area-based threshold for selection would not be triggered. This PR adjust the threshold logic to be based on width+height of the selection box rather than area.

Before:
![2024-05-31 11 04 36](https://github.com/AirLabsTeam/react-drag-to-select/assets/1098408/89d468cd-6558-4b18-8d39-9b87b20880d4)

After:
![2024-05-31 11 07 35](https://github.com/AirLabsTeam/react-drag-to-select/assets/1098408/256c1c90-671e-4a1b-b2dd-4697213b99bc)
