### PR TITLE
fix : getPointFromEvent remove rect argument

### DIFF
--- a/src/hooks/useSelectionLogic.ts
+++ b/src/hooks/useSelectionLogic.ts
@@ -84,10 +84,8 @@ export function useSelectionLogic<T extends HTMLElement>({
    * method to calculate point from event in context of the whole screen
    */
   const getPointFromEvent = useCallback(
-    (event: MouseEvent, rect?: DOMRect): Point => {
-      if (!rect) {
-        rect = containerRef.current?.getParentBoundingClientRect();
-      }
+    (event: MouseEvent): Point => {
+      const rect = containerRef.current?.getParentBoundingClientRect();
 
       return {
         x: event.clientX - (typeof rect?.left === 'number' ? rect.left : 0),
@@ -146,7 +144,7 @@ export function useSelectionLogic<T extends HTMLElement>({
       }
 
       const rect = containerRef.current?.getParentBoundingClientRect();
-      endPoint.current = getPointFromEvent(event, rect);
+      endPoint.current = getPointFromEvent(event);
       handleMouseMove(event, rect);
     },
     [handleMouseMove, getPointFromEvent, containerRef],


### PR DESCRIPTION
Summary
This PR removes an unused parameter from the function 'getPointFromEvent' to improve code clarity and maintainability. After reviewing the code, it was confirmed that this parameter is not being utilized and can safely be removed without impacting functionality.

Reason for Change
Removing unused parameters helps reduce code complexity and avoids confusion for future developers. This small change contributes to cleaner and more maintainable code.

Impact
This change has no impact on the current behavior of the application since the parameter is not being used anywhere.