### PR TITLE
feat(selection): Introduce transformOnMove callback to be able to change selection rectangle

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Check out this codesandbox for a complete working example: https://codesandbox.i
 |`onSelectionStart`|No|`() => void`||Method called when selection starts (mouse is down and moved)|
 |`onSelectionEnd`|No|`() => void`||Method called when selection ends (mouse is up)
 |`onSelectionChange`|Yes|`(box: Box) => void`||Method called when selection moves|
+|`transformOnMove`|No|`(box: Box) => void`||Method is called on selection move and allows to transform current selection e.g. to snap it to a grid|
 |`isEnabled`|No|`boolean`|`true`|If false, selection does not fire|
 |`eventsElement`|No|`Window`, `HTMLElement` or `null`|`window`|Element to listen mouse events|
 |`selectionProps`|No|`React.HTMLAttributes`||Props of selection - you can pass style here as shown below|

--- a/src/hooks/useSelectionContainer.tsx
+++ b/src/hooks/useSelectionContainer.tsx
@@ -20,6 +20,7 @@ export interface UseSelectionContainerParams<T extends HTMLElement>
     | 'onSelectionChange'
     | 'onSelectionEnd'
     | 'onSelectionStart'
+    | 'transformOnMove'
     | 'isEnabled'
     | 'eventsElement'
     | 'shouldStartSelecting'
@@ -40,6 +41,7 @@ export function useSelectionContainer<T extends HTMLElement>(
     onSelectionChange,
     onSelectionEnd,
     onSelectionStart,
+    transformOnMove,
     isEnabled = true,
     selectionProps = {},
     eventsElement,
@@ -54,6 +56,7 @@ export function useSelectionContainer<T extends HTMLElement>(
     onSelectionEnd,
     onSelectionStart,
     onSelectionChange,
+    transformOnMove,
     isEnabled,
     eventsElement,
     shouldStartSelecting,

--- a/src/hooks/useSelectionLogic.ts
+++ b/src/hooks/useSelectionLogic.ts
@@ -13,6 +13,8 @@ export interface UseSelectionLogicParams<T extends HTMLElement> {
   onSelectionEnd?: (event: MouseEvent) => void;
   /** This callback will fire when the user's mouse changes position while selecting using requestAnimationFrame */
   onSelectionChange?: OnSelectionChange;
+  /** This callback is being called on selection move and allows to transform current selection e.g. to snap it to a grid  */
+  transformOnMove?: (selection: Box) => void;
   /** This boolean enables selecting  */
   isEnabled?: boolean;
   /** This is an HTML element that the mouse events (mousedown, mouseup, mousemove) should be attached to. Defaults to the document.body */
@@ -48,6 +50,7 @@ export function useSelectionLogic<T extends HTMLElement>({
   onSelectionChange,
   onSelectionStart,
   onSelectionEnd,
+  transformOnMove,
   isEnabled = true,
   eventsElement,
   shouldStartSelecting,
@@ -121,6 +124,8 @@ export function useSelectionLogic<T extends HTMLElement>({
           endPoint: endPoint.current,
         });
 
+        transformOnMove?.(newSelectionBox);
+
         // calculate box in context of container to compare with items' coordinates
         const boxInContainer: SelectionBox = {
           ...newSelectionBox,
@@ -145,7 +150,7 @@ export function useSelectionLogic<T extends HTMLElement>({
         cancelCurrentSelection();
       }
     },
-    [cancelCurrentSelection, containerRef],
+    [cancelCurrentSelection, containerRef, transformOnMove],
   );
 
   const onMouseMove = useCallback(


### PR DESCRIPTION
It would be beneficial if we can transform current selection e.g. for snapping to a grid. See example  


https://github.com/user-attachments/assets/04e14cb2-0e57-48b2-aec9-ac31dedff1c0



